### PR TITLE
[Bug] [High] Stepper layout spacing is sometimes far to high

### DIFF
--- a/StepperPlugin/StepperPlugin/ARStepperView.swift
+++ b/StepperPlugin/StepperPlugin/ARStepperView.swift
@@ -72,36 +72,12 @@ struct ARStepperView: View {
     var body: some View {
         ScrollView() {
             StepperView()
-                .addSteps(
-                    self.viewModel.stepperItems.map({ step in
-                        HStack {
-                            VStack(alignment: .leading) {
-                                Text(step.title).font(.headline)
-                                Spacer()
-                                Text(step.text).font(.caption)
-                            }
-                            Spacer()
-                            Image(systemName: "chevron.right").font(.body).foregroundColor(.gray)
-                        }
-                        .contentShape(Rectangle())
-                        .onTapGesture {
-                            navigator.continue(selecting: step)
-                        }
-                    })
-                )
-                .indicators(
-                    self.viewModel.stepperItems.map({ step -> StepperIndicationType<AnyView> in
-                        return StepperIndicationType.custom(
-                            ARStepperIconView(
-                                image: Image(systemName: step.sfSymbol),
-                                width: 40,
-                                color: step.style == "primary" ? .white : primaryColor(),
-                                strokeColor: step.style == "primary" ? .white : primaryColor(),
-                                circleFillColor: step.style == "primary" ? primaryColor() : .white
-                            ).eraseToAnyView())
-
-                    })
-                )
+                .addSteps(viewModel.stepperItems.map({ step in
+                    StepItemView(step: step, onTap: navigator.continue(selecting:))
+                }))
+                .indicators(viewModel.stepperItems.map({ step in
+                    step.indicatorView(primaryColor: primaryColor())
+                }))
                 .stepIndicatorMode(StepperMode.vertical)
                 .spacing(50)
                 .lineOptions(StepperLineOptions.custom(2, primaryColor()))

--- a/StepperPlugin/StepperPlugin/ARStepperView.swift
+++ b/StepperPlugin/StepperPlugin/ARStepperView.swift
@@ -45,6 +45,7 @@ struct StepItemView: View {
             Spacer()
             Image(systemName: "chevron.right").font(.body).foregroundColor(.gray)
         }
+        .contentShape(Rectangle())
         .onTapGesture { onTap(self.step) }
     }
 }

--- a/StepperPlugin/StepperPlugin/ARStepperView.swift
+++ b/StepperPlugin/StepperPlugin/ARStepperView.swift
@@ -31,6 +31,38 @@ class ARStepModel: ObservableObject {
     }
 }
 
+struct StepItemView: View {
+    let step: StepperItem
+    var onTap: (StepperItem) -> Void
+    
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading) {
+                Text(step.title).font(.headline)
+                Spacer().frame(maxHeight: 8.0)
+                Text(step.text).font(.caption)
+            }
+            Spacer()
+            Image(systemName: "chevron.right").font(.body).foregroundColor(.gray)
+        }
+        .onTapGesture { onTap(self.step) }
+    }
+}
+
+extension StepperItem {
+    var primaryStyle: Bool { style == "primary" }
+    
+    func indicatorView(primaryColor: Color) -> StepperIndicationType<ARStepperIconView> {
+        StepperIndicationType.custom(ARStepperIconView(
+            image: Image(systemName: sfSymbol),
+            width: 40,
+            color: primaryStyle ? .white : primaryColor,
+            strokeColor: primaryStyle ? .white : primaryColor,
+            circleFillColor: primaryStyle ? primaryColor : .white
+        ))
+    }
+}
+
 struct ARStepperView: View {
     @EnvironmentObject var step: ObservableStep
     @StateObject var viewModel: ARStepModel


### PR DESCRIPTION
### Task

[[Bug] [High] Stepper layout spacing is sometimes far to high](https://3.basecamp.com/5245563/buckets/26145695/todos/5509666496/edit?replace=true)

### Feature/Issue

On a fresh display of the screen, each item grows more than it should

### Implementation

1. The indicator and step content were moved into method/classes to avoid issues with type erasure. The library used to do the steps heavily uses `AnyView` internally and the combination of that with `some View` responses was creating geometry calculation issues. By creating the classes, the type is better at measuring its contents.

2. A max height of 8 points was added to the spacing between the title and text in the stepper item. To avoid having the item request too much area to draw.

### Demonstration

https://user-images.githubusercontent.com/2117340/203610041-60ed1295-cbfc-4f2b-a53b-3a57d13b5f98.mp4
